### PR TITLE
Deprecation notice: SCMS files now included in ACM project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# ⚠️ DEPRECATION NOTICE
+This repository is no longer needed, as the SCMS files are now included directly in the [asn1_codec](https://www.github.com/usdot-jpo-ode/asn1_codec) project. It is considered deprecated and may be archived or removed soon.
+
+---
+
 # scms-asn1
 
 This repository contains the ASN.1 definitions for data containers and protocols


### PR DESCRIPTION
## Problem
The scms-asn1 repository is no longer necessary, as its contents (SCMS files) are now integrated directly into the ACM project. Without clear communication, users may continue to use or contribute to this deprecated repository unnecessarily.

## Solution
Added a deprecation notice at the top of the README.md to inform users that this repository is deprecated and may be archived or removed soon.

